### PR TITLE
support Homekey on the HSU interface

### DIFF
--- a/src/PN532_HSU.h
+++ b/src/PN532_HSU.h
@@ -5,14 +5,14 @@
 #include "PN532Interface.h"
 #include "Arduino.h"
 
-#define PN532_HSU_DEBUG
+#define PN532_HSU_DEBUG 1
 
 #define PN532_HSU_READ_TIMEOUT (1000)
 
 class PN532_HSU : public PN532Interface
 {
 public:
-    PN532_HSU(HardwareSerial &serial);
+    PN532_HSU(HardwareSerial &serial, uint8_t tx = 0, uint8_t rx = 0);
 
     void begin();
     void wakeup();
@@ -21,6 +21,8 @@ public:
 
 private:
     HardwareSerial *_serial;
+    uint8_t _tx_pin;
+    uint8_t _rx_pin;
     uint8_t command;
 
     int8_t readAckFrame();


### PR DESCRIPTION
As I do not have enough wires between the ESP32 and the PN532, I've connected my reader to a serial interface.

This PR contains the necessary patches to the PN532 library. Using it is quite simple. Just replace the PN532_SPI class with the PN532_HSU class. Like this:

```patch
diff --git a/src/main.cpp b/src/main.cpp
index 7c99768..0274815 100644
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include <utils.h>
 #include "HomeSpan.h"
 #include <SPI.h>
-#include <PN532_SPI.h>
+#include <PN532_HSU.h>
 #include "PN532.h"
 #include "HAP.h"
 #include <chrono>
@@ -26,9 +26,8 @@ enum lockStates
   LOCKING
 };

-#define PN532_SS (5)
-PN532_SPI pn532spi(SPI, PN532_SS);
-PN532 nfc(pn532spi);
+PN532_HSU pn532hsu(Serial2, 16, 17);
+PN532 nfc(pn532hsu);